### PR TITLE
No autoconfiguration on Logback's ServiceLoader, this happens too early

### DIFF
--- a/src/main/resources/META-INF/services/ch.qos.logback.classic.spi.Configurator
+++ b/src/main/resources/META-INF/services/ch.qos.logback.classic.spi.Configurator
@@ -1,1 +1,0 @@
-org.irenical.slf4j.LoggerConfigurator


### PR DESCRIPTION
I don't want this here, it breaks my stuff. Putting the LoggerConfigurator in Logback's ServiceLoader causes slf4jindy to be configured while SLF4J is first loading, doing it this early causes SLF4J to complain because we'll inevitably attempt to get loggers during SLF4J initialisation. There's too many classes that can be involved in configuration loading that we don't control (namely Archaius stuff), we can't get rid of all their loggers.

I'd rather let SLF4J initialize with a basic Logback configuration and then reconfigure Logback in a more controlled way, but I have no way of initialising a basic Logback configuration programatically if this thing is here.

Thoughts?
