### PR TITLE
Don't disable the JUL level propagator when installing the JUL bridge

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
   <packaging>jar</packaging>
 
   <properties>
-    <slf4j.version>1.7.18</slf4j.version>
-    <logback.version>1.1.3</logback.version>
+    <slf4j.version>1.7.21</slf4j.version>
+    <logback.version>1.1.7</logback.version>
     <jindy.version>1.5.0</jindy.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.irenical.slf4j</groupId>
   <artifactId>slf4jindy</artifactId>
-  <version>1.2.3</version>
+  <version>1.2.4-SNAPSHOT</version>
 
   <name>SLF4Jindy</name>
   <description>SLF4J Binding</description>
@@ -20,7 +20,7 @@
   <properties>
     <slf4j.version>1.7.18</slf4j.version>
     <logback.version>1.1.3</logback.version>
-    <jindy.version>1.4.2</jindy.version>
+    <jindy.version>1.5.0</jindy.version>
   </properties>
 
   <scm>

--- a/src/main/java/org/irenical/slf4j/LoggerConfigurator.java
+++ b/src/main/java/org/irenical/slf4j/LoggerConfigurator.java
@@ -38,15 +38,13 @@ public class LoggerConfigurator extends GenericConfigurator implements Configura
   private static final int DEFAULT_FILE_MAXBACKUPS = 5;
   private static final String DEFAULT_BACKUP_DATE_PATERN = "%d{yyyy-MM-dd}";
 
-  private static final String LOGGING_LEVEL_CHANGE_PROPAGATOR_ENABLED = "logging.levelchangepropagator.enabled";
-
   private static final String EXT = ".log";
 
   private static final String SEP = "-";
 
   private static volatile boolean started = false;
 
-  private final Config CONFIG = ConfigFactory.getConfig();
+  private final Config config = ConfigFactory.getConfig();
 
   public LoggerConfigurator() {
   }
@@ -62,14 +60,14 @@ public class LoggerConfigurator extends GenericConfigurator implements Configura
   }
 
   protected void initListeners() {
-    CONFIG.listen(LEVEL, this::updateLevel);
-    CONFIG.listen(CONSOLE_ENABLED, this::updateConsole);
-    CONFIG.listen(CONSOLE_PATTERN, this::updateConsole);
-    CONFIG.listen(FILE_ENABLED, this::updateFile);
-    CONFIG.listen(FILE_PATTERN, this::updateFile);
-    CONFIG.listen(FILE_MAXBACKUPS, this::updateFile);
-    CONFIG.listen(FILE_PATH, this::updateFile);
-    CONFIG.listen(FILE_BACKUP_DATE_PATTERN, this::updateFile);
+    config.listen(LEVEL, this::updateLevel);
+    config.listen(CONSOLE_ENABLED, this::updateConsole);
+    config.listen(CONSOLE_PATTERN, this::updateConsole);
+    config.listen(FILE_ENABLED, this::updateFile);
+    config.listen(FILE_PATTERN, this::updateFile);
+    config.listen(FILE_MAXBACKUPS, this::updateFile);
+    config.listen(FILE_PATH, this::updateFile);
+    config.listen(FILE_BACKUP_DATE_PATTERN, this::updateFile);
   }
 
   @Override
@@ -92,14 +90,11 @@ public class LoggerConfigurator extends GenericConfigurator implements Configura
       SLF4JBridgeHandler.removeHandlersForRootLogger();
       SLF4JBridgeHandler.install();
     }
-    String got = System.getProperty(LOGGING_LEVEL_CHANGE_PROPAGATOR_ENABLED);
-    if (got == null || got.equalsIgnoreCase("true")) {
-      LevelChangePropagator julLevelChanger = new LevelChangePropagator();
-      julLevelChanger.setContext(loggerContext);
-      julLevelChanger.setResetJUL(true);
-      julLevelChanger.start();
-      loggerContext.addListener(julLevelChanger);
-    }
+    LevelChangePropagator julLevelChanger = new LevelChangePropagator();
+    julLevelChanger.setContext(loggerContext);
+    julLevelChanger.setResetJUL(true);
+    julLevelChanger.start();
+    loggerContext.addListener(julLevelChanger);
   }
 
   private void updateFile() {
@@ -108,31 +103,31 @@ public class LoggerConfigurator extends GenericConfigurator implements Configura
       Logger logbackLogger = loggerContext.getLogger(Logger.ROOT_LOGGER_NAME);
 
       RollingFileAppender<ILoggingEvent> fileAppender = (RollingFileAppender<ILoggingEvent>) logbackLogger.getAppender(APPENDER_FILE);
-      if (CONFIG.getBoolean(FILE_ENABLED, false)) {
+      if (config.getBoolean(FILE_ENABLED, false)) {
         logbackLogger.detachAppender(fileAppender);
 
         fileAppender = new RollingFileAppender<>();
         fileAppender.setName(APPENDER_FILE);
         fileAppender.setContext(loggerContext);
 
-        String file = CONFIG.getString(FILE_PATH, DEFAULT_FILE_PATH);
+        String file = config.getString(FILE_PATH, DEFAULT_FILE_PATH);
         if (!file.endsWith("/")) {
           file += "/";
         }
 
-        fileAppender.setFile(file + CONFIG.getString("application") + EXT);
+        fileAppender.setFile(file + config.getString("application") + EXT);
 
         TimeBasedRollingPolicy<ILoggingEvent> rollPolicy = new TimeBasedRollingPolicy<>();
         rollPolicy.setContext(loggerContext);
-        rollPolicy.setFileNamePattern(file + CONFIG.getString("application") + SEP + CONFIG.getString(FILE_BACKUP_DATE_PATTERN, DEFAULT_BACKUP_DATE_PATERN) + EXT);
-        rollPolicy.setMaxHistory(CONFIG.getInt(FILE_MAXBACKUPS, DEFAULT_FILE_MAXBACKUPS));
+        rollPolicy.setFileNamePattern(file + config.getString("application") + SEP + config.getString(FILE_BACKUP_DATE_PATTERN, DEFAULT_BACKUP_DATE_PATERN) + EXT);
+        rollPolicy.setMaxHistory(config.getInt(FILE_MAXBACKUPS, DEFAULT_FILE_MAXBACKUPS));
         rollPolicy.setParent(fileAppender);
         fileAppender.setRollingPolicy(rollPolicy);
         fileAppender.setTriggeringPolicy(rollPolicy);
 
         PatternLayoutEncoder encoder = new PatternLayoutEncoder();
         encoder.setContext(loggerContext);
-        encoder.setPattern(CONFIG.getString(FILE_PATTERN, DEFAULT_PATTERN));
+        encoder.setPattern(config.getString(FILE_PATTERN, DEFAULT_PATTERN));
         fileAppender.setEncoder(encoder);
 
         logbackLogger.addAppender(fileAppender);
@@ -153,7 +148,7 @@ public class LoggerConfigurator extends GenericConfigurator implements Configura
     Logger logbackLogger = loggerContext.getLogger(Logger.ROOT_LOGGER_NAME);
 
     ConsoleAppender<ILoggingEvent> consoleAppender = (ConsoleAppender<ILoggingEvent>) logbackLogger.getAppender(APPENDER_CONSOLE);
-    if (CONFIG.getBoolean(CONSOLE_ENABLED, true)) {
+    if (config.getBoolean(CONSOLE_ENABLED, true)) {
       logbackLogger.detachAppender(consoleAppender);
 
       consoleAppender = new ConsoleAppender<>();
@@ -162,7 +157,7 @@ public class LoggerConfigurator extends GenericConfigurator implements Configura
 
       PatternLayoutEncoder encoder = new PatternLayoutEncoder();
       encoder.setContext(loggerContext);
-      encoder.setPattern(CONFIG.getString(CONSOLE_PATTERN, DEFAULT_PATTERN));
+      encoder.setPattern(config.getString(CONSOLE_PATTERN, DEFAULT_PATTERN));
       consoleAppender.setEncoder(encoder);
       encoder.start();
       consoleAppender.start();
@@ -176,7 +171,7 @@ public class LoggerConfigurator extends GenericConfigurator implements Configura
   private void updateLevel() {
     LoggerContext loggerContext = (LoggerContext) getContext();
     Logger logbackLogger = loggerContext.getLogger(Logger.ROOT_LOGGER_NAME);
-    String level = CONFIG.getString(LEVEL, "DEBUG");
+    String level = config.getString(LEVEL, "DEBUG");
     switch (level) {
     case "ERROR":
       logbackLogger.setLevel(Level.ERROR);

--- a/src/main/java/org/irenical/slf4j/LoggerConfigurator.java
+++ b/src/main/java/org/irenical/slf4j/LoggerConfigurator.java
@@ -73,6 +73,7 @@ public class LoggerConfigurator extends GenericConfigurator implements Configura
   @Override
   public void configure(LoggerContext loggerContext) {
     if (!started) {
+      setContext(loggerContext);
       initListeners();
       started = true;
     }
@@ -84,6 +85,14 @@ public class LoggerConfigurator extends GenericConfigurator implements Configura
   }
 
   private void installJulBridge() {
+    // Workaround for strange ClassCircularityErrors in the JUL bridge when very strange classloader hierarchies are
+    // set up and logging occurs from inside classloaders themselves (eg: some strange Tomcat deployments)
+    try {
+      Class.forName("java.util.logging.LogRecord");
+    } catch (ClassNotFoundException e) {
+      throw new AssertionError(e);
+    }
+
     LoggerContext loggerContext = (LoggerContext) getContext();
 
     if (!SLF4JBridgeHandler.isInstalled()) {


### PR DESCRIPTION
There should be no use case for installing the JUL SLF4J bridge while at the same time not enabling the LevelChangePropagator, unless your goal is to [tremendously slow down things](http://www.slf4j.org/legacy.html#jul-to-slf4j).

What was the problem you were trying to fix here?
